### PR TITLE
Fix prompt_dir where directory contains more than one space

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -695,7 +695,7 @@ set_default POWERLEVEL9K_DIR_PATH_SEPARATOR "/"
 set_default POWERLEVEL9K_HOME_FOLDER_ABBREVIATION "~"
 set_default POWERLEVEL9K_DIR_SHOW_WRITABLE false
 prompt_dir() {
-  local current_path=$(pwd | sed -e "s,^$HOME,~,")
+  local current_path="$(pwd | sed -e "s,^$HOME,~,")"
   if [[ -n "$POWERLEVEL9K_SHORTEN_DIR_LENGTH" || "$POWERLEVEL9K_SHORTEN_STRATEGY" == "truncate_with_folder_marker" ]]; then
     set_default POWERLEVEL9K_SHORTEN_DELIMITER $'\U2026'
 


### PR DESCRIPTION
If directory contains more than one space, you get a "not valid in this context error".

```
user@host > ~/a/b/c/directory with spaces >
$ cd test
prompt_dir:local:1: not valid in this context: spaces/test
```